### PR TITLE
refactor: use forked cchardet to detect encoding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.26.65
-charset-normalizer==3.3.0
+faust-cchardet==2.1.19
 pandas==1.5.3
 pytest==7.2.1
 python-dateutil==2.8.2


### PR DESCRIPTION
Using the forked version of the [original `cchardet`](https://github.com/PyYoshi/cChardet): [`faust-cchardet`](https://github.com/faust-streaming/cChardet) to detect encoding. In the future, `faust-cchardet` could become the baseline of the package (see [this issue](https://github.com/faust-streaming/cChardet/issues/32)), so we might want to switch back to just `cchardet` in the requirements (they are both imported with `import cchardet`)